### PR TITLE
Fixed Minor Bug

### DIFF
--- a/lib/opene/parser.py
+++ b/lib/opene/parser.py
@@ -414,7 +414,7 @@ class Parser:
                                 print("Function: {}".format(tokens[i].value))
                             elif (tokens[i].value in DataManager.global_variables):
                                 variable_value = self.debug_variable(tokens[i].value)
-                                if (variable_value):
+                                if (variable_value is not False):
                                     data_out = "{} <- {}".format(tokens[i].value, self.debug_variable(tokens[i].value))
                                     print(data_out)
                                     if (self.output_location):


### PR DESCRIPTION
Essentially, if you set a variable to 0 in a program then tried to get its value, by just writing the variable name, then because it would return 0, it would believe that the variable was not found. As a result, I have slightly changed a line to fix this.