### PR TITLE
Fixed error with split_string

### DIFF
--- a/externals/stringlib.py
+++ b/externals/stringlib.py
@@ -39,7 +39,7 @@ class Functions:
                 elif (delimiter.type == "list"):
                     for item in delimiter.value:
                         if (item.type == "string"):
-                            delimiters.append(delimiter.value[1:-1])
+                            delimiters.append(item.value[1:-1])
                 else:
                     pass  # Todo: Raise error
         else:


### PR DESCRIPTION
Fixed an error with the split_string function, when using custom delimiters.