### PR TITLE
Updated the lexer

### DIFF
--- a/lib/opene/lexer.py
+++ b/lib/opene/lexer.py
@@ -1,3 +1,6 @@
+from typing import Union
+
+
 class Traceback:
     """
     This is the Traceback class
@@ -14,7 +17,7 @@ class Token:
     """
     def __init__(self,
                  _type: str,
-                 value: str,
+                 value: Union[str, list],
                  line: int = 0,
                  col: int = 0,
                  char: str = None):


### PR DESCRIPTION
As lists and matrixes are stored as lists in OpenE and it previously only accepted strings, it has now been updated to take strings and lists